### PR TITLE
add .gitattributes file to format ASP files properly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.lp linguist-language=Prolog
+*.asp linguist-language=Prolog


### PR DESCRIPTION
We usually use the `.lp` (logic program) suffix for Answer Set Programs, because GitHub (and most people) think a `*.asp` file is a Microsoft Active Server Pages script.

Since there's no MS ASP in this repo, and since `spliced` already seems to generate `atoms.asp` files, I added some help for *both* `*.lp` and `*.asp` files.  This should get us nice code formatting and correct code stats.